### PR TITLE
Fix: CSV can't be parsed

### DIFF
--- a/src/include/csv.js
+++ b/src/include/csv.js
@@ -111,7 +111,7 @@ WMEAC.csv.push(new WMEAC.ClassCSV({version: 1, regexpValidation: [/.*/, // 1st c
                                                                   /(Yes)|(No)/, // ignore trafic = permanent
                                                                   /^(\d+(;|$))+/, // seg ID list
                                                                   /(lon=(-?\d+\.?\d*)&lat=(-?\d+\.?\d*))|(lat=(-?\d+\.?\d*)&lon=(-?\d+\.?\d*))/, // lonlat
-                                                                  /^\d$/, // zoom
+                                                                  /^\d\d+$/, // zoom
                                                                   /(^$)|(^-?\d+\.-?\d+\.-?\d+$)/ // MTE ID is empty or digits.digits.digits
                                                                   ]}));
                                                                   


### PR DESCRIPTION
Zoom field validation accepts 1 or 2 digits instead of only one.