### PR TITLE
Fixed closure deletion

### DIFF
--- a/src/include/actionClosures.js
+++ b/src/include/actionClosures.js
@@ -162,8 +162,11 @@ WMEAC.removeClosure = function (closures, successHandler, failureHandler)
     var cab = require("Waze/Modules/Closures/Models/ClosureActionBuilder");
     var sc = require("Waze/Modules/Closures/Models/SharedClosure");
     var t = {};
-    var c = new sc({closures: [].concat(closures)}, {dataModel: W.model, segmentSelection: W.selectionManager.getSegmentSelection(), isNew: true});
-    t.actions=[cab.delete(c)];
+    let segs = WMEAC.segmentsIDsToSegments(closures.map(closure => closure.attributes.segID));
+    segs = segs.filter(function (seg) {
+        return seg.isAllowed(seg.permissionFlags.EDIT_CLOSURES);
+    });
+    t.actions=[cab.delete(W.model, new sc({segments: segs, closures: closures, reverseSegments: W.selectionManager.getReversedSegments()}, {dataModel: W.model, segmentSelection: W.selectionManager.getSegmentSelection(), isNew: true}))];
     W.controller.save(t).then(done()).catch(fail());
     return true;
 };

--- a/src/include/class.closure.js
+++ b/src/include/class.closure.js
@@ -103,11 +103,11 @@ WMEAC.ClassClosure = function (options)
             // look for closure(s)
             var that = this;
             var closures = W.model.roadClosures.getObjectArray(function (c) {
-                return (c.startDate==that.startDate &&
-                        c.endDate==that.endDate &&
-                        c.reason.trim()==that.reason &&
-                        c.segID==s.attributes.id &&
-                        c.permanent == (that.permanent=='Yes'));
+                return (c.attributes.startDate==that.startDate &&
+                        c.attributes.endDate==that.endDate &&
+                        c.attributes.reason.trim()==that.reason &&
+                        c.attributes.segID==s.attributes.id &&
+                        c.attributes.permanent == (that.permanent=='Yes'));
             });
             if ((this.direction=="TWO WAY") || // && closures.length==2 && closures[0].forward!=closures[1].forward) ||
                 (this.direction=="A to B" && closures.length==1 && closures[0].forward==true) ||


### PR DESCRIPTION
Hello everyone,

After a bit of reverse-engineering, I have been able to fix the deletion of closures using a csv of closures where `add` was replaced with `remove` (identical data).

I am not totally sure that this work in all cases but it made me able to delete a few closures.

This DOES NOT FIX the fact that `check segments` checks for adding closures even with the `remove` keyword.

Best,

Maël